### PR TITLE
Allow adding all files, rather than just binary executables

### DIFF
--- a/update-chroot/update-chroot.sh
+++ b/update-chroot/update-chroot.sh
@@ -447,7 +447,7 @@ install_ld() {
             "$CHROOT_ROOT_D/lib/x86_64-linux-gnu"
     $COPY /lib64/ld-linux* "$CHROOT_ROOT_D/lib64/"
   else
-    libcheck="$(ls /lib/ld-linux* 2> /dev/null | wc -l)"
+    libcheck="$(find /lib/ -maxdepth 1 -name 'ld-linux*' 2>/dev/null | wc -l)"
     if [[ $libcheck -ne 0 ]]; then
       $COPY /lib/ld-linux* /lib/libnss_*.so.2  "$CHROOT_ROOT_D/lib"
     fi
@@ -602,7 +602,6 @@ full_rebuild() {
     apply_template "--apply" "$domain"
   done
   echo -e "\\e[32mDone!\\e[m Successfully rebuilt and reappplied template."
-  exit 0
 }
 
 ###########################################################

--- a/update-chroot/update-chroot.sh
+++ b/update-chroot/update-chroot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-### Copyright 1999-2022. Plesk International GmbH.
+### Copyright 1999-2024. WebPros International GmbH.
 
 ###############################################################################
 # This script manages and updates chroot environment used in Plesk
@@ -313,16 +313,12 @@ install_chroot_program() {
   case "$filetype" in
     application/octet-stream*|\
     application/x-executable*|\
-    application/x-shellscript*|\
-    text/x-shellscript*|\
     application/x-sharedlib*|\
-	application/x-pie-executable*|\
-    text/x-perl*)
+    application/x-pie-executable*)
       install_libs "$path"
     ;;
     *)
-      warn "$path is not a program (filetype $filetype), skipping."
-      return 2
+      warn "$path is not an binary executable (filetype $filetype). Shared libraries will not be copied."
     ;;
   esac
 


### PR DESCRIPTION
Closes https://github.com/plesk/kb-scripts/issues/45.
Additionally, finally closes long-lasting Shellcheck warnings for inappropriate `ls` usage instead of calling `find`.