### PR TITLE
Remove 35 condition

### DIFF
--- a/varnishmng/varnishmng.sh
+++ b/varnishmng/varnishmng.sh
@@ -368,20 +368,12 @@ function disableVarnishOnDomain(){
 }
 
 function menuDisableVarnishOnDomain(){
-  if [ `availableDomainsList |wc -l` -lt "35" ] ; then
-      menuDomainSelect
-  else
-      read -p "Disabling varnish... Enter domain name: " domainName
-  fi
+  menuDomainSelect
   disableVarnishOnDomain "$selectedDomain"
 }
 
 function menuEnableVarnishOnDomain(){
-  if [ `availableDomainsList |wc -l` -lt "35" ] ; then
-    menuDomainSelect
-  else
-    read -p "Enabling varnish... Enter domain name: " domainName
-  fi
+  menuDomainSelect
   enableVarnishOnDomain "$selectedDomain"
 }
 


### PR DESCRIPTION
WIth that condition and more than 35 domains the list of domains was not shown and you had to type the domain name manually. With the change you can get a list of all domains. I tested with 50 domains.