### PR TITLE
Fix CentOS 7 MariaDB upgrade script

### DIFF
--- a/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
+++ b/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
@@ -28,9 +28,9 @@ echo "setting up the repository"
 echo "#http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/10.5/centos7-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1" > /etc/yum.repos.d/mariadb.repo
+baseurl = https://dlm.mariadb.com/repo/mariadb-server/10.5.26/yum/rhel/7/$(uname -m)/
+gpgkey = https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY
+gpgcheck = 1" > /etc/yum.repos.d/mariadb.repo
 
 yum makecache
 

--- a/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
+++ b/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
@@ -23,6 +23,17 @@ if [ -f "/etc/yum.repos.d/MariaDB.repo" ] ; then
   mv /etc/yum.repos.d/MariaDB.repo /etc/yum.repos.d/mariadb.repo
 fi
 
+echo "setting up the repository"
+
+echo "#http://downloads.mariadb.org/mariadb/repositories/
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.5/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1" > /etc/yum.repos.d/mariadb.repo
+
+yum makecache
+
 #Stopping MariaDB
 echo "stopping MariaDB service"
 systemctl stop mariadb
@@ -35,13 +46,6 @@ echo "removing mysql-server package in case it exists"
 rpm -e --nodeps "`rpm -q --whatprovides mariadb-server`"
 
 echo "Upgrading MariaDB"
-
-echo "#http://downloads.mariadb.org/mariadb/repositories/
-[mariadb]
-name = MariaDB
-baseurl = http://yum.mariadb.org/10.5/centos7-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1" > /etc/yum.repos.d/mariadb.repo
 
 yum clean all
 

--- a/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
+++ b/c7-mariadb-10-5-upgrade/c7-mariadb-10-5-upgrade.sh
@@ -7,6 +7,8 @@
 # Version      : 1.0
 #########
 
+set -e  # Stop on the first error. Append '|| true' to failing commands if needed to ignore the failure.
+
 LOG_FILE=plesk_mariadbupdate.log
 ERROR_LOG_FILE=plesk_updatemariadb_error.log
 


### PR DESCRIPTION
- Stop on the first failure. Previously, the script ignored all failing commands and proceeded to destroy the system.
- Verify that the repository works early (by running `makecache`), before doing anything dangerous.
- Switch to https://dlm.mariadb.com/repo/mariadb-server/10.5.26/yum/rhel/7/ repository, as there will be no updates anyway. http://yum.mariadb.org/10.5/centos7-amd64 did not work today.